### PR TITLE
Bump up tools and library dependency versions

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ apply from: 'maven-push.gradle'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 10

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "uk.co.barbuzz.beerprogressview.sample"
@@ -22,8 +22,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.3.0'
-    compile 'com.android.support:design:23.3.0'
+    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:design:23.4.0'
 
     compile project(path: ':library')
     compile 'com.roughike:bottom-bar:1.3.3'


### PR DESCRIPTION
Upon opening the project and syncing with AS 3.0.1 we receive
warnings that the tools declared are too low and should be updated.

Also consume the latest patch level for declared support libraries.